### PR TITLE
fixes #5 CharacterTabSwitcherコンポーネント

### DIFF
--- a/app/character/[characterId]/CharacterTabSwitcher/CharacterTabSwitcher.tsx
+++ b/app/character/[characterId]/CharacterTabSwitcher/CharacterTabSwitcher.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type CharacterTabLinkProps = React.ComponentProps<
+  typeof Link<`/character/${string}`>
+>;
+
+function CharacterTabLink(props: CharacterTabLinkProps) {
+  const pathname = usePathname();
+  return (
+    <Link
+      {...props}
+      data-selected-link={pathname == props.href ? true : undefined}
+    />
+  );
+}
+
+export type CharacterTabSwitcherProps = {
+  characterId: string;
+};
+
+export function CharacterTabSwitcher({
+  characterId,
+}: CharacterTabSwitcherProps) {
+  const pathname = usePathname();
+  return (
+    <ul>
+      <li>
+        <CharacterTabLink href={`/character/${characterId}`}>
+          About
+        </CharacterTabLink>
+      </li>
+      <li>
+        <CharacterTabLink href={`/character/${characterId}/get`}>
+          Get
+        </CharacterTabLink>
+      </li>
+    </ul>
+  );
+}

--- a/app/character/[characterId]/get/page.tsx
+++ b/app/character/[characterId]/get/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Get Page</div>;
+}


### PR DESCRIPTION
## 概要
Resolve #5 

`/character/[characterId]`下の画面で、`/character/[characterId]`と`/character/[characterId]/get`を行き来できるリンクのリストを実装します。

![image](https://github.com/denpalog/denpalog/assets/51913600/cc4fa0da-3cf8-4073-af10-eed3a42c65d2)

## テスト
- [x] About リンクをクリックしたとき、`/character/[characterId]`に遷移すること
- [x] Get リンクをクリックしたとき、`/character/[characterId]/get`に遷移すること
- [x] `/character/[characterId]`では、Aboutへのリンクに`data-selected-link`属性が付与されること
- [x] `/character/[characterId]/get`では、Getへのリンクに`data-selected-link`属性が付与されること