### PR TITLE
fix #43 migrate用scriptsでmigrationの名前を対話的に指定できるよう修正する

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "migrate:local": "dotenv -e .env.local -- pnpx prisma migrate dev --name init"
+    "migrate:local": "dotenv -e .env.local -- pnpx prisma migrate dev"
   },
   "dependencies": {
     "@nextui-org/react": "^2.2.10",


### PR DESCRIPTION
## 概要
#43 

## テスト

- [x]  `pnpm run migrate:local`を実行したときに、migrationの名前が指定できること 