### PR TITLE
 Prettierがpnpm-lock.yamlをフォーマットしないようにする #49

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "prisma.prisma"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}


### PR DESCRIPTION
## 概要
Resolves #49 
.prettierignoreを作成して、pnpm-lock.yamlをフォーマットしないようにすること。

## テスト
- [x] pnpm-lock.yamlにはフォーマットがされないこと。
- [x] page.tsxにはフォーマットがされること。

## その他
<!--上記の他に書くことがあれば書く-->
