### PR TITLE
 Chromaticを導入する #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+build-storybook.log
 
 # debug
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "migrate:local": "dotenv -e .env.local -- pnpx prisma migrate dev",
-    "tcm": "tcm -p 'app/**/*.module.css'"
+    "tcm": "tcm -p 'app/**/*.module.css'",
+    "chromatic": "dotenv -e .env.local -- chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "@chakra-ui/next-js": "^2.2.0",
@@ -43,6 +44,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.17",
+    "chromatic": "^11.0.8",
     "dotenv-cli": "^7.4.0",
     "eslint": "^8",
     "eslint-config-next": "14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ devDependencies:
   autoprefixer:
     specifier: ^10.4.17
     version: 10.4.17(postcss@8.4.35)
+  chromatic:
+    specifier: ^11.0.8
+    version: 11.0.8
   dotenv-cli:
     specifier: ^7.4.0
     version: 7.4.1
@@ -6436,6 +6439,19 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /chromatic@11.0.8:
+    resolution: {integrity: sha512-+zJ5h0/Eu5z26KCNLIw2tknbK69gUO8q3Jsew4oU0Q/i/NPhIwcXhvPP7u75aLJgX1EI61+ndiGJA/yeQZQcgw==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
     dev: true
 
   /chrome-trace-event@1.0.3:


### PR DESCRIPTION
## 概要
Resolves #16 
`pnpm add chromatic`でchromaticを導入する。
Storybookによるコンポーネントカタログをオンラインで閲覧できるようにする。

## テスト
- [x] オンラインでStorybookによるコンポーネントカタログをオンラインで閲覧できる。

## その他
`.env.local`にトークンを書いた。
