### PR TITLE
schema.prismaをPrisma拡張機能でformatするようにする #55

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-    "recommendations": [
-        "esbenp.prettier-vscode",
-        "prisma.prisma"
-    ]
+  "recommendations": ["esbenp.prettier-vscode", "prisma.prisma"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[prisma]": {
+    "editor.defaultFormatter": "Prisma.prisma"
+  }
 }


### PR DESCRIPTION
## 概要
Resolves #55 
<!--やったことをここに書く-->
VSCodeの設定を変更し、schema.prismaをPrisma拡張機能でformatするようにした。

## テスト
- [x] schema.prismaがフォーマットされる。
- [x] page.tsxがフォーマットされる。

## その他
<!--上記の他に書くことがあれば書く-->
